### PR TITLE
Fix audio playback outside of Colab

### DIFF
--- a/mt3/colab/music_transcription_with_transformers.ipynb
+++ b/mt3/colab/music_transcription_with_transformers.ipynb
@@ -509,7 +509,12 @@
         "audio = load_audio(sample_rate=SAMPLE_RATE)\n",
         "log_event('uploadAudioComplete', {'value': round(len(audio) / SAMPLE_RATE)})\n",
         "\n",
-        "note_seq.notebook_utils.colab_play(audio, sample_rate=SAMPLE_RATE)"
+        "try:\n",
+        "  import google.colab  # noqa: F401\n",
+        "  note_seq.notebook_utils.colab_play(audio, sample_rate=SAMPLE_RATE)\n",
+        "except ModuleNotFoundError:\n",
+        "  from IPython.display import Audio, display\n",
+        "  display(Audio(audio, rate=SAMPLE_RATE))"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- handle non-Colab environments when playing uploaded audio in the demo notebook

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'absl')*

------
https://chatgpt.com/codex/tasks/task_e_683dc9b9c42083279543b1cb10518ba0